### PR TITLE
25 - Central Portal migration

### DIFF
--- a/.github/.m2/settings.xml
+++ b/.github/.m2/settings.xml
@@ -9,9 +9,9 @@
   <pluginGroups />
   <servers>
     <server>
-      <id>ossrh</id>
-      <username>${env.OSSRH_USERNAME}</username>
-      <password>${env.OSSRH_PASSWORD}</password>
+      <id>central</id>
+      <username>${env.CENTRAL_USERNAME}</username>
+      <password>${env.CENTRAL_PASSWORD}</password>
     </server>
   </servers>
   <mirrors />

--- a/.github/workflows/manual-SNAPSHOT.yml
+++ b/.github/workflows/manual-SNAPSHOT.yml
@@ -64,9 +64,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: ${{ secrets.OSS_SONATYPE_ORG_USER }}
-          server-password: ${{ secrets.OSS_SONATYPE_ORG_PASSWORD }}
+          server-id: central # the default server id for Sonatype Central Repository
+          server-username: ${{ secrets.CENTRAL_SONATYPE_ORG_USER }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_ORG_PASSWORD }}
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Build with Maven
@@ -76,5 +76,5 @@ jobs:
         run: mvn -B -Pparent-pom-release deploy -DskipStaging=true -Dgpg.skip=true -s $GITHUB_WORKSPACE/.github/.m2/settings.xml
         env:
           GITHUB_TOKEN: '${{ secrets.GH_TOKEN_TECHUSER_JAVA }}'
-          OSSRH_USERNAME: '${{ secrets.OSS_SONATYPE_ORG_USER }}'
-          OSSRH_PASSWORD: '${{ secrets.OSS_SONATYPE_ORG_PASSWORD }}'
+          CENTRAL_USERNAME: '${{ secrets.CENTRAL_SONATYPE_ORG_USER }}'
+          CENTRAL_PASSWORD: '${{ secrets.CENTRAL_SONATYPE_ORG_PASSWORD }}'

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: central # the default server id for Sonatype Central Repository
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       # Buildelt fajlok alairas tesztelese
@@ -110,6 +110,6 @@ jobs:
       - name: mvn -B release:perform
         env:
           GPG_KEY_ID_GITHUB_TECHUSER: ${{ secrets.GPG_KEY_ID_GITHUB_TECHUSER }}
-          OSSRH_USERNAME: '${{ secrets.OSS_SONATYPE_ORG_USER }}'
-          OSSRH_PASSWORD: '${{ secrets.OSS_SONATYPE_ORG_PASSWORD }}'
+          CENTRAL_USERNAME: '${{ secrets.CENTRAL_SONATYPE_ORG_USER }}'
+          CENTRAL_PASSWORD: '${{ secrets.CENTRAL_SONATYPE_ORG_PASSWORD }}'
         run: mvn -B -Pparent-pom-release release:perform -Dgpg.keyname=$GPG_KEY_ID_GITHUB_TECHUSER -s $GITHUB_WORKSPACE/.github/.m2/settings.xml

--- a/docs/en/migration.adoc
+++ b/docs/en/migration.adoc
@@ -4,3 +4,4 @@
 include::migration/migration110to120.adoc[leveloffset=+1]
 include::migration/migration120to130.adoc[leveloffset=+1]
 include::migration/migration130to140.adoc[leveloffset=+1]
+include::migration/migration140to150.adoc[leveloffset=+1]

--- a/docs/en/migration/migration140to150.adoc
+++ b/docs/en/migration/migration140to150.adoc
@@ -1,0 +1,18 @@
+= v1.4.0 → v1.5.0
+
+parent-pom v1.4.0 -> v1.5.0 Migration Description, New Features, and Changes Description
+
+== New Features
+
+=== parent-pom
+
+.Plugin change:
+* org.sonatype.plugins:nexus-staging-maven-plugin 1.6.13 -> org.sonatype.central:central-publishing-maven-plugin 0.8.0
+
+==== Migration
+
+* Open Source Maven projects under https://github.com/i-Cell-Mobilsoft-Open-Source using `parent-oss-pom` should update their Sonatype credentials
+and server ids in their GitHub workflows and settings.xml like so:
+** server-id: ossrh -> central
+** secrets.OSS_SONATYPE_ORG_USER -> secrets.CENTRAL_SONATYPE_ORG_USER
+** secrets.OSS_SONATYPE_ORG_PASSWORD -> secrets.CENTRAL_SONATYPE_ORG_PASSWORD

--- a/docs/en/release/release-howto.adoc
+++ b/docs/en/release/release-howto.adoc
@@ -1,4 +1,5 @@
 = Release process
+
 Since the project serves as a legacy for other projects, it should be given a non-"classic" release maven configuration.
 The reason is that this would cause the target project to inherit the project settings, and that would lead to very unwanted events.
 So all release settings should be hidden under a *parent-pom-release* `maven profile`.
@@ -28,6 +29,7 @@ The clean release process itself consists of 4 steps:
 === #1 Check
 This step is used to verify from a technical point of view that all the settings and release requirements for maven are met.
 In short, the following happens:
+
 * all changes are committed
 * the code can be translated 
 * tests can be run successfully
@@ -70,6 +72,7 @@ mvn -B -Pparent-pom-release release:prepare
 * _release:prepare_ part of maven-release-plugin, starts the release of the SCM side version
 
 This step often fails on the first run (in a new environment) and these are the main reasons why:
+
 * environment settings are not prepared to run console maven, git and java
 * the local `settings.xml` file does not have the authentication details of the servers in pom.xml expanded
 * the java version does not include server certificates (this is usually the biggest pain in the ass)

--- a/docs/migration.adoc
+++ b/docs/migration.adoc
@@ -4,3 +4,4 @@
 include::migration/migration110to120.adoc[leveloffset=+1]
 include::migration/migration120to130.adoc[leveloffset=+1]
 include::migration/migration130to140.adoc[leveloffset=+1]
+include::migration/migration140to150.adoc[leveloffset=+1]

--- a/docs/migration/migration140to150.adoc
+++ b/docs/migration/migration140to150.adoc
@@ -1,0 +1,18 @@
+= v1.4.0 → v1.5.0
+
+parent-pom v1.4.0 -> v1.5.0 migrációs leírás, újdonságok, változások leírása
+
+== Újdonságok
+
+=== parent-pom
+
+.Plugin csere:
+* org.sonatype.plugins:nexus-staging-maven-plugin 1.6.13 -> org.sonatype.central:central-publishing-maven-plugin 0.8.0
+
+==== Átállás
+
+* Open Source Maven projektek a https://github.com/i-Cell-Mobilsoft-Open-Source alatt, akik a `parent-oss-pom`-ot használják frissíteniük kell Sonatype bejelentkezési adataikat
+és szerver azonosítóikat a GitHub workflow-kban és a settings.xml fájlban a következőképpen:
+** server-id: ossrh -> central
+** secrets.OSS_SONATYPE_ORG_USER -> secrets.CENTRAL_SONATYPE_ORG_USER
+** secrets.OSS_SONATYPE_ORG_PASSWORD -> secrets.CENTRAL_SONATYPE_ORG_PASSWORD

--- a/docs/pom/pom.adoc
+++ b/docs/pom/pom.adoc
@@ -28,9 +28,10 @@ Tartalma csak teljesen általános elemekből áll, icellmobilsoft cégre utaló
 * maven verzió minimum követelmény
 
 .Profilok:
-* jdk8 - aktiválódik hogyha JDK 8 -es környezettel kompiláljuk a projektet
+* jdk8 - aktiválódik hogyha JDK 8 -as környezettel kompiláljuk a projektet
 * jdk11 - aktiválódik hogyha JDK 11 -es környezettel kompiláljuk a projektet
 * jdk17 - aktiválódik hogyha JDK 17 -es környezettel kompiláljuk a projektet
+* jdk21 - aktiválódik hogyha JDK 21 -es környezettel kompiláljuk a projektet
 * parent-pom-release - kézzel kell aktiválni hogyha a 'parent-pom'-ból új release-t készítünk
 
 == parent-icellmobilsoft-pom

--- a/docs/release/release-howto.adoc
+++ b/docs/release/release-howto.adoc
@@ -1,4 +1,5 @@
 = Releaselési folyamat
+
 Mivel a projekt ősként szolgál a többi projekten, így azt figyelembe véve nem "klasszikus" release maven beállításokkal kell ellátni.
 Az ok hogy ennek a projekt beállításait leörökölné a cél projekt, és az nagyon nem kívánt eseményekhez vezetne.
 Tehát minden release beállítást egy *parent-pom-release* `maven profile` alá kell rejteni.
@@ -28,6 +29,7 @@ Maga a tiszta release folyamat 4 lépésből áll:
 === #1 Ellenőrzés
 Ez a lépés szolgál arra, hogy technikai oldalról ellenőrizzük le, hogy a maven minden beállítása és release követelménye megvan.
 Röviden a következő történik:
+
 * minden változás commitolva van
 * fordítható a kód
 * tesztek sikeresen le tudnak futni
@@ -70,6 +72,7 @@ mvn -B -Pparent-pom-release release:prepare
 * _release:prepare_ maven-release-plugin része, indítja az SCM oldali verzió kiadását
 
 Ez a lépés gyakran hibára fut első futásnál (új környezetben), melynek a legfőbb okai ezek szoktak lenni:
+
 * környezeti beállítások nincsenek felkészítve konzolos maven, git és java futásra
 * lokális `settings.xml` fájlban nincsenek rözgítve a pom.xml-ben szereplő szerverek authentikációs adatai
 * a java verzióban nincsenek benne a szerverek tanusítványai (ez szok lenni a legnyagyobb szívás)

--- a/icellmobilsoft/pom.xml
+++ b/icellmobilsoft/pom.xml
@@ -102,21 +102,4 @@
 			<layout>default</layout>
 		</snapshotRepository>
 	</distributionManagement>
-
-	<profiles>
-		<profile>
-			<id>parent-pom-release</id>
-
-			<distributionManagement>
-				<snapshotRepository>
-					<id>central</id>
-					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
-				</snapshotRepository>
-				<repository>
-					<id>central</id>
-					<url>https://repo.maven.apache.org/maven2</url>
-				</repository>
-			</distributionManagement>
-		</profile>
-	</profiles>
 </project>

--- a/icellmobilsoft/pom.xml
+++ b/icellmobilsoft/pom.xml
@@ -109,14 +109,49 @@
 
 			<distributionManagement>
 				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+					<id>central</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 				</snapshotRepository>
 				<repository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+					<id>central</id>
+					<url>https://repo.maven.apache.org/maven2</url>
 				</repository>
 			</distributionManagement>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.1.0</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<gpgArguments>
+								<arg>--pinentry-mode</arg>
+								<arg>loopback</arg>
+							</gpgArguments>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>0.8.0</version>
+						<extensions>true</extensions>
+						<configuration>
+							<autoPublish>true</autoPublish>
+							<waitUntil>published</waitUntil>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 </project>

--- a/icellmobilsoft/pom.xml
+++ b/icellmobilsoft/pom.xml
@@ -117,41 +117,6 @@
 					<url>https://repo.maven.apache.org/maven2</url>
 				</repository>
 			</distributionManagement>
-
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.1.0</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<gpgArguments>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.sonatype.central</groupId>
-						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.8.0</version>
-						<extensions>true</extensions>
-						<configuration>
-							<autoPublish>true</autoPublish>
-							<waitUntil>published</waitUntil>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 	</profiles>
 </project>

--- a/oss/pom.xml
+++ b/oss/pom.xml
@@ -18,17 +18,6 @@
 		</license>
 	</licenses>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>central</id>
-			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
-		</snapshotRepository>
-		<repository>
-			<id>central</id>
-			<url>https://repo.maven.apache.org/maven2</url>
-		</repository>
-	</distributionManagement>
-
 	<build>
 		<pluginManagement>
 			<plugins>

--- a/oss/pom.xml
+++ b/oss/pom.xml
@@ -114,34 +114,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>parent-pom-release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.1.0</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<gpgArguments>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/oss/pom.xml
+++ b/oss/pom.xml
@@ -9,10 +9,6 @@
 	<artifactId>parent-oss-pom</artifactId>
 	<packaging>pom</packaging>
 
-	<properties>
-		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-	</properties>
-
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
@@ -21,6 +17,17 @@
 			<comments>A business-friendly OSS license</comments>
 		</license>
 	</licenses>
+
+	<distributionManagement>
+		<snapshotRepository>
+			<id>central</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+		</snapshotRepository>
+		<repository>
+			<id>central</id>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
+	</distributionManagement>
 
 	<build>
 		<pluginManagement>
@@ -79,6 +86,16 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.sonatype.central</groupId>
+					<artifactId>central-publishing-maven-plugin</artifactId>
+					<version>0.8.0</version>
+					<extensions>true</extensions>
+					<configuration>
+						<autoPublish>true</autoPublish>
+						<waitUntil>published</waitUntil>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -91,24 +108,16 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
 		<profile>
-			<id>release</id>
-
-			<distributionManagement>
-				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-				</snapshotRepository>
-				<repository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-				</repository>
-			</distributionManagement>
-
+			<id>parent-pom-release</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -129,18 +138,6 @@
 								<arg>--pinentry-mode</arg>
 								<arg>loopback</arg>
 							</gpgArguments>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${nexus-staging-maven-plugin.version}</version>
-						<extensions>true</extensions>
-						<configuration>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<serverId>ossrh</serverId>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
-							<keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -457,18 +457,16 @@
 			<properties>
 				<project.scm.id>icell-github-server</project.scm.id>
 				<developerConnection>scm:git:git@github.com:i-Cell-Mobilsoft-Open-Source/parent-pom.git</developerConnection>
-
-				<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
 			</properties>
 
 			<distributionManagement>
 				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+					<id>central</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 				</snapshotRepository>
 				<repository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+					<id>central</id>
+					<url>https://repo.maven.apache.org/maven2</url>
 				</repository>
 			</distributionManagement>
 
@@ -495,15 +493,13 @@
 						</configuration>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${nexus-staging-maven-plugin.version}</version>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>0.8.0</version>
 						<extensions>true</extensions>
 						<configuration>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<serverId>ossrh</serverId>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
-							<keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
+							<autoPublish>true</autoPublish>
+							<waitUntil>published</waitUntil>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -459,17 +459,6 @@
 				<developerConnection>scm:git:git@github.com:i-Cell-Mobilsoft-Open-Source/parent-pom.git</developerConnection>
 			</properties>
 
-			<distributionManagement>
-				<snapshotRepository>
-					<id>central</id>
-					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
-				</snapshotRepository>
-				<repository>
-					<id>central</id>
-					<url>https://repo.maven.apache.org/maven2</url>
-				</repository>
-			</distributionManagement>
-
 			<build>
 				<plugins>
 					<plugin>
@@ -500,6 +489,7 @@
 						<configuration>
 							<autoPublish>true</autoPublish>
 							<waitUntil>published</waitUntil>
+							<centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
* fő pom: 
  * parent-pom-release profil változott a `central-publishing-maven-plugin`-nal 
* parent-icellmobilsoft-pom
  * érvényes rá a fő pom profilja
* parent-oss-pom
  * alapként bekerült a `central-publishing-maven-plugin` így azok a projektek akik ebből az oss pom-bók származnak ezt fogják default használni
  * érvényes rá a fő pom profilja
* GitHub workflow-kban az új central-os új server id, user, pass van használva